### PR TITLE
Change function includes to indexOf for compatibility with old webvie…

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -430,7 +430,7 @@ function drawSchedule(file, date, diffMap, title, containerID, criticalPath, ign
                             color: fontColor
                         },
                         formatter: function () {
-                            if (highlights.includes(this.value)) {
+                            if (highlights.indexOf(this.value) !== -1) {
                                 return '<b>' + this.value + '</b>';
                             }
                             return this.value;


### PR DESCRIPTION
Change function includes to indexOf for compatibility with old webviews on android phones. (I see this problem on one old phone before kitkat)

Includes : [Source](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/Array/includes)

indexOf : [Source](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/Array/indexOf)